### PR TITLE
#3: Generate ISO11649 Reference

### DIFF
--- a/generator/src/main/java/net/codecrete/qrbill/generator/Bill.java
+++ b/generator/src/main/java/net/codecrete/qrbill/generator/Bill.java
@@ -297,6 +297,19 @@ public class Bill implements Serializable {
     public void setReferenceNo(String referenceNo) {
         this.referenceNo = referenceNo;
     }
+    
+    /**
+     * Creates a ISO11649 creditor reference from a raw String by prefixing the String with "RF"
+     * and the modulo 97 checksum.
+     * Sets the created reference number 
+     * @param rawReference The raw String. spaces are removed
+     * @throws IllegalArgumentException if the rawReference contains invalid characters
+     */
+    public void createSetCreditorReference(String rawReference) {
+        final String whiteSpaceRemoved = Strings.whiteSpaceRemoved(rawReference);
+        final int modulo = Strings.calculateMod97("RF00" + whiteSpaceRemoved);
+        setReferenceNo(String.format("RF%02d", 98-modulo) + whiteSpaceRemoved);
+    }
 
     /**
      * Gets the additional unstructured message.

--- a/generator/src/main/java/net/codecrete/qrbill/generator/PaymentValidation.java
+++ b/generator/src/main/java/net/codecrete/qrbill/generator/PaymentValidation.java
@@ -215,26 +215,11 @@ class PaymentValidation {
     }
 
     private static boolean hasValidMod97CheckDigits(String number) {
-        String rearranged = number.substring(4) + number.substring(0, 4);
-        int len = rearranged.length();
-        int sum = 0;
-        for (int i = 0; i < len; i++) {
-            char ch = rearranged.charAt(i);
-            if (ch >= '0' && ch <= '9') {
-                sum = sum * 10 + (ch - '0');
-            } else if (ch >= 'A' && ch <= 'Z') {
-                sum = sum * 100 + (ch - 'A' + 10);
-            } else if (ch >= 'a' && ch <= 'z') {
-                sum = sum * 100 + (ch - 'a' + 10);
-            } else {
-                return false;
-            }
-            if (sum > 9999999)
-                sum = sum % 97;
+        try {
+            return Strings.calculateMod97(number) == 1;
+        } catch (IllegalArgumentException e) {
+            return false;
         }
-
-        sum = sum % 97;
-        return sum == 1;
     }
 
     private static boolean isNumeric(String value) {

--- a/generator/src/main/java/net/codecrete/qrbill/generator/Strings.java
+++ b/generator/src/main/java/net/codecrete/qrbill/generator/Strings.java
@@ -79,4 +79,33 @@ class Strings {
     static boolean isNullOrEmpty(String value) {
         return value == null || value.trim().length() == 0;
     }
+
+	/**
+	 * Convert a string to an integer and calculate modulo 97 according to ISO11649 and IBAN
+	 * checksum standard
+	 * @param reference
+	 * @return
+	 */
+    static int calculateMod97(String reference) throws IllegalArgumentException {
+        String rearranged = reference.substring(4) + reference.substring(0, 4);
+        int len = rearranged.length();
+        int sum = 0;
+        for (int i = 0; i < len; i++) {
+            char ch = rearranged.charAt(i);
+            if (ch >= '0' && ch <= '9') {
+                sum = sum * 10 + (ch - '0');
+            } else if (ch >= 'A' && ch <= 'Z') {
+                sum = sum * 100 + (ch - 'A' + 10);
+            } else if (ch >= 'a' && ch <= 'z') {
+                sum = sum * 100 + (ch - 'a' + 10);
+            } else {
+                throw new IllegalArgumentException("Invalid character in reference: " + ch);
+            }
+            if (sum > 9999999)
+                sum = sum % 97;
+        }
+
+        sum = sum % 97;
+        return sum;
+    }
 }

--- a/generator/src/test/java/net/codecrete/qrbill/generator/ISO11649Test.java
+++ b/generator/src/test/java/net/codecrete/qrbill/generator/ISO11649Test.java
@@ -1,0 +1,27 @@
+package net.codecrete.qrbill.generator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ISO11649Test {
+
+    @Test
+    public void modulo97() {
+        Assert.assertEquals("should calculate from mixed case string", 79, Strings.calculateMod97("RF00AB2g59x56V543"));
+    }
+
+    @Test
+    public void createIso11649() {
+        Bill bill = new Bill();
+        bill.createSetCreditorReference("AB2G5 9X56 V543");
+        Assert.assertEquals("RF19AB2G59X56V543", bill.getReferenceNo());
+
+        Assert.assertTrue(PaymentValidation.isValidISO11649ReferenceNo(bill.getReferenceNo()));
+
+        //zero padding the checksum
+        bill.createSetCreditorReference("7");
+        Assert.assertEquals("RF097", bill.getReferenceNo());
+        Assert.assertTrue(PaymentValidation.isValidISO11649ReferenceNo(bill.getReferenceNo()));
+    }
+
+}


### PR DESCRIPTION
mod97 calculation moved to Strings so it can be used both for validating
and generating the reference