### PR TITLE
Check validity of creditor/debtor country code

### DIFF
--- a/generator/src/main/java/net/codecrete/qrbill/generator/Payments.java
+++ b/generator/src/main/java/net/codecrete/qrbill/generator/Payments.java
@@ -402,6 +402,19 @@ public class Payments {
         return true;
     }
 
+    static boolean isAlpha(String value) {
+        int len = value.length();
+        for (int i = 0; i < len; i++) {
+            char ch = value.charAt(i);
+            if (ch >= 'A' && ch <= 'Z')
+                continue;
+            if (ch >= 'a' && ch <= 'z')
+                continue;
+            return false;
+        }
+        return true;
+    }
+
     private static boolean isValidQRBillCharacter(char ch) {
         if (ch < 0x20)
             return false;

--- a/generator/src/main/java/net/codecrete/qrbill/generator/Validator.java
+++ b/generator/src/main/java/net/codecrete/qrbill/generator/Validator.java
@@ -16,6 +16,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+import static java.util.Locale.getISOCountries;
+
 /**
  * Internal class for validating and cleaning QR bill data.
  */
@@ -24,6 +26,7 @@ class Validator {
     private final Bill billIn;
     private final Bill billOut;
     private final ValidationResult validationResult;
+    private final List<String> isoCountries = Arrays.asList(getISOCountries());
 
     /**
      * Validates the QR bill data and returns the validation messages (if any) and
@@ -253,7 +256,7 @@ class Validator {
         checkMandatoryAddressFields(addressOut, fieldRoot);
 
         if (addressOut.getCountryCode() != null
-                && (addressOut.getCountryCode().length() != 2 || !Payments.isAlphaNumeric(addressOut.getCountryCode())))
+                && (addressOut.getCountryCode().length() != 2 || !isoCountries.contains(addressOut.getCountryCode())))
             validationResult.addMessage(Type.ERROR, fieldRoot + ValidationConstants.SUBFIELD_COUNTRY_CODE,
                     ValidationConstants.KEY_VALID_COUNTRY_CODE);
 

--- a/generator/src/main/java/net/codecrete/qrbill/generator/Validator.java
+++ b/generator/src/main/java/net/codecrete/qrbill/generator/Validator.java
@@ -16,8 +16,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
-import static java.util.Locale.getISOCountries;
-
 /**
  * Internal class for validating and cleaning QR bill data.
  */
@@ -26,7 +24,6 @@ class Validator {
     private final Bill billIn;
     private final Bill billOut;
     private final ValidationResult validationResult;
-    private final List<String> isoCountries = Arrays.asList(getISOCountries());
 
     /**
      * Validates the QR bill data and returns the validation messages (if any) and
@@ -256,7 +253,7 @@ class Validator {
         checkMandatoryAddressFields(addressOut, fieldRoot);
 
         if (addressOut.getCountryCode() != null
-                && (addressOut.getCountryCode().length() != 2 || !isoCountries.contains(addressOut.getCountryCode())))
+                && (addressOut.getCountryCode().length() != 2 || !Payments.isAlpha(addressOut.getCountryCode())))
             validationResult.addMessage(Type.ERROR, fieldRoot + ValidationConstants.SUBFIELD_COUNTRY_CODE,
                     ValidationConstants.KEY_VALID_COUNTRY_CODE);
 

--- a/generator/src/test/java/net/codecrete/qrbill/generatortest/CreditorValidationTest.java
+++ b/generator/src/test/java/net/codecrete/qrbill/generatortest/CreditorValidationTest.java
@@ -147,6 +147,16 @@ class CreditorValidationTest extends BillDataValidationBase {
     }
 
     @Test
+    void creditorWithInvalidCountryCode3() {
+        bill = SampleData.getExample1();
+        Address address = createValidPerson();
+        address.setCountryCode("00");
+        bill.setCreditor(address);
+        validate();
+        assertSingleErrorMessage(ValidationConstants.FIELD_CREDITOR_COUNTRY_CODE, "valid_country_code");
+    }
+
+    @Test
     void creditorWithConflictingAddress() {
         bill = SampleData.getExample1();
         bill.getCreditor().setAddressLine1("Conflict");

--- a/generator/src/test/java/net/codecrete/qrbill/generatortest/CreditorValidationTest.java
+++ b/generator/src/test/java/net/codecrete/qrbill/generatortest/CreditorValidationTest.java
@@ -157,6 +157,16 @@ class CreditorValidationTest extends BillDataValidationBase {
     }
 
     @Test
+    void creditorWithInvalidCountryCode4() {
+        bill = SampleData.getExample1();
+        Address address = createValidPerson();
+        address.setCountryCode("aà");
+        bill.setCreditor(address);
+        validate();
+        assertSingleErrorMessage(ValidationConstants.FIELD_CREDITOR_COUNTRY_CODE, "valid_country_code");
+    }
+
+    @Test
     void creditorWithConflictingAddress() {
         bill = SampleData.getExample1();
         bill.getCreditor().setAddressLine1("Conflict");

--- a/generator/src/test/java/net/codecrete/qrbill/generatortest/DebtorValidationTest.java
+++ b/generator/src/test/java/net/codecrete/qrbill/generatortest/DebtorValidationTest.java
@@ -99,4 +99,14 @@ class DebtorValidationTest extends BillDataValidationBase {
         validate();
         assertSingleErrorMessage(ValidationConstants.FIELD_DEBTOR_COUNTRY_CODE, "valid_country_code");
     }
+
+    @Test
+    void creditorWithInvalidCountryCode2() {
+        bill = SampleData.getExample1();
+        Address address = createValidPerson();
+        address.setCountryCode("aà");
+        bill.setCreditor(address);
+        validate();
+        assertSingleErrorMessage(ValidationConstants.FIELD_CREDITOR_COUNTRY_CODE, "valid_country_code");
+    }
 }

--- a/generator/src/test/java/net/codecrete/qrbill/generatortest/DebtorValidationTest.java
+++ b/generator/src/test/java/net/codecrete/qrbill/generatortest/DebtorValidationTest.java
@@ -89,4 +89,14 @@ class DebtorValidationTest extends BillDataValidationBase {
         assertNoMessages();
         assertNull(validatedBill.getDebtor());
     }
+
+    @Test
+    void debtorWithInvalidCountryCode() {
+        bill = SampleData.getExample1();
+        Address address = createValidPerson();
+        address.setCountryCode("00");
+        bill.setDebtor(address);
+        validate();
+        assertSingleErrorMessage(ValidationConstants.FIELD_DEBTOR_COUNTRY_CODE, "valid_country_code");
+    }
 }


### PR DESCRIPTION
Currently creditor/debtor country code is syntactically checked (it must be 2 characters long). However, country code is not semantically checked, and thus 2-characters strings like `00` are deemed as valid country code.

This PR strengths the validation of creditor/debtor country code checking that it belongs to the list provided by the method `java.util.Locale.getISOCountries`.
This change makes the validation more compliant with the "Swiss Implementation Guidelines QR-bill" that requires creditor/debtor country code to be a 2-characters code defined in the  ISO 3166-1 standard.