### PR TITLE
Add ability to configure left margin offset inside receipt section …

### DIFF
--- a/generator/src/main/java/net/codecrete/qrbill/generator/BillFormat.java
+++ b/generator/src/main/java/net/codecrete/qrbill/generator/BillFormat.java
@@ -23,6 +23,8 @@ public class BillFormat implements Serializable {
     private String fontFamily = "Helvetica,Arial,\"Liberation Sans\"";
     private GraphicsFormat graphicsFormat = GraphicsFormat.SVG;
     private int resolution = 144;
+    private int marginLeftOffset = 0;
+    private int marginRigthOffset = 0;
 
     /**
      * Creates a new instance with default values
@@ -43,6 +45,8 @@ public class BillFormat implements Serializable {
         fontFamily = format.fontFamily;
         graphicsFormat = format.graphicsFormat;
         resolution = format.resolution;
+        marginLeftOffset = format.marginLeftOffset;
+        marginRigthOffset = format.marginRigthOffset;
     }
 
     /**
@@ -190,6 +194,50 @@ public class BillFormat implements Serializable {
 		this.resolution = resolution;
 	}
 
+    /**
+     * Gets the offset for the left margin.
+     *
+     * <p>
+     * Defaults to 0
+     * </p>
+     *
+     * @return width, in mm
+     */
+    public int getMarginLeftOffset() {
+		return marginLeftOffset;
+	}
+
+    /**
+     * Sets the offset for the left margin.
+     *
+     * @param marginLeftOffset width, in mm
+     */
+	public void setMarginLeftOffset(int marginLeftOffset) {
+		this.marginLeftOffset = marginLeftOffset;
+	}
+
+    /**
+     * Gets the offset for the rigth margin.
+     *
+     * <p>
+     * Defaults to 0
+     * </p>
+     *
+     * @return width, in mm
+     */
+    public int getMarginRigthOffset() {
+        return marginRigthOffset;
+    }
+
+    /**
+     * Sets the offset for the rigth margin.
+     *
+     * @param marginRigthOffset width, in mm
+     */
+    public void setMarginRigthOffset(int marginRigthOffset) {
+        this.marginRigthOffset = marginRigthOffset;
+    }
+
 	/**
      * {@inheritDoc}
      */
@@ -203,7 +251,9 @@ public class BillFormat implements Serializable {
                 separatorType == that.separatorType &&
                 Objects.equals(fontFamily, that.fontFamily) &&
                 graphicsFormat == that.graphicsFormat &&
-                resolution == that.resolution;
+                resolution == that.resolution &&
+                marginLeftOffset == that.marginLeftOffset &&
+                marginRigthOffset == that.marginRigthOffset;
     }
 
     /**
@@ -227,6 +277,8 @@ public class BillFormat implements Serializable {
                 ", fontFamily='" + fontFamily + '\'' +
                 ", graphicsFormat=" + graphicsFormat +
                 ", resolution=" + resolution +
+                ", deltaMarginLeft=" + marginLeftOffset +
+                ", deltaMarginRigth=" + marginRigthOffset +
                 '}';
     }
 }

--- a/generator/src/main/java/net/codecrete/qrbill/generator/BillLayout.java
+++ b/generator/src/main/java/net/codecrete/qrbill/generator/BillLayout.java
@@ -84,7 +84,7 @@ class BillLayout {
 
         boolean isTooTight;
         while (true) {
-            breakLines(PP_INFO_SECTION_WIDTH);
+            breakLines(PP_INFO_SECTION_WIDTH - bill.getFormat().getMarginRigthOffset());
             isTooTight = computePaymentPartSpacing();
             if (!isTooTight || textFontSize == PP_TEXT_MIN_FONT_SIZE)
                 break;
@@ -100,16 +100,17 @@ class BillLayout {
 
         labelFontSize = RC_LABEL_PREF_FONT_SIZE;
         textFontSize = RC_TEXT_PREF_FONT_SIZE;
-        breakLines(RECEIPT_TEXT_WIDTH);
+        double receiptTextWidthAdapted = RECEIPT_TEXT_WIDTH - bill.getFormat().getMarginLeftOffset();
+        breakLines(receiptTextWidthAdapted);
         isTooTight = computeReceiptSpacing();
         if (isTooTight) {
             prepareReducedReceiptText(false);
-            breakLines(RECEIPT_TEXT_WIDTH);
+            breakLines(receiptTextWidthAdapted);
             isTooTight = computeReceiptSpacing();
         }
         if (isTooTight) {
             prepareReducedReceiptText(true);
-            breakLines(RECEIPT_TEXT_WIDTH);
+            breakLines(receiptTextWidthAdapted);
             computeReceiptSpacing();
         }
         drawReceipt();
@@ -224,7 +225,7 @@ class BillLayout {
     private void drawReceipt() throws IOException {
 
         // "Receipt" title
-        graphics.setTransformation(MARGIN, 0, 0, 1, 1);
+        graphics.setTransformation(MARGIN + bill.getFormat().getMarginLeftOffset(), 0, 0, 1, 1);
         yPos = SLIP_HEIGHT - MARGIN - graphics.getAscender(FONT_SIZE_TITLE);
         graphics.putText(getText(MultilingualText.KEY_RECEIPT), 0, yPos, FONT_SIZE_TITLE, true);
 
@@ -284,7 +285,7 @@ class BillLayout {
             y -= (textFontSize + 3) * PT_TO_MM;
             graphics.putText(amount, CURRENCY_WIDTH_RC, y, textFontSize, false);
         } else {
-            drawCorners(RECEIPT_TEXT_WIDTH - AMOUNT_BOX_WIDTH_RC,
+            drawCorners(RECEIPT_TEXT_WIDTH - bill.getFormat().getMarginLeftOffset() - AMOUNT_BOX_WIDTH_RC,
                     AMOUNT_SECTION_TOP - AMOUNT_BOX_HEIGHT_RC,
                     AMOUNT_BOX_WIDTH_RC, AMOUNT_BOX_HEIGHT_RC);
         }
@@ -297,7 +298,7 @@ class BillLayout {
         String label = getText(MultilingualText.KEY_ACCEPTANCE_POINT);
         double y = ACCEPTANCE_POINT_SECTION_TOP - labelAscender;
         double w = graphics.getTextWidth(label, labelFontSize, true);
-        graphics.putText(label, RECEIPT_TEXT_WIDTH - w, y, labelFontSize, true);
+        graphics.putText(label, RECEIPT_TEXT_WIDTH - bill.getFormat().getMarginLeftOffset() - w, y, labelFontSize, true);
     }
 
     private boolean computePaymentPartSpacing() {


### PR DESCRIPTION
…and right margin offset inside informations sections to be compliant with more printers

Currently the margin used arround the layout are the minimal required margin : 5mm
Some printers can not print with so small margin.

The PR adds the ability to configure a left and right margin offset to ensure that the "information" section is not cut off on the right and the "receipt" section is not cut off on the left.
All this without changing the rest of the layout and still respecting the specifications.